### PR TITLE
Import __version__ properly in __init__.py.

### DIFF
--- a/ipyscales/__init__.py
+++ b/ipyscales/__init__.py
@@ -5,7 +5,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 
-from ._version import *
+from ._version import __version__, version_info
 
 from .scale import ScaleWidget
 from .linear import LinearScaleWidget


### PR DESCRIPTION
`import *` doesn't include symbols starting with underscore.