### PR TITLE
Add ordinal color maps

### DIFF
--- a/docs/source/examples/colormaps.nblink
+++ b/docs/source/examples/colormaps.nblink
@@ -1,0 +1,3 @@
+{
+  "path": "../../../examples/colormaps.ipynb"
+}

--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -16,5 +16,6 @@ The widgets have been embedded into the page for demonstrative purposes.
     :glob:
 
     introduction
+    colormaps
     colorbar
     scaled-data

--- a/examples/colormaps.ipynb
+++ b/examples/colormaps.ipynb
@@ -1,0 +1,399 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Color maps"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ipyscales import (\n",
+    "    LinearColorScale, LogColorScale, NamedSequentialColorMap, NamedDivergingColorMap,\n",
+    "    NamedOrdinalColorMap, ColorBar\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import display\n",
+    "\n",
+    "def visualize(cm):\n",
+    "    display(ColorBar(\n",
+    "        colormap=cm,\n",
+    "        length=500,\n",
+    "        orientation='horizontal'\n",
+    "    ))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c9d89b646aef4a73aaf6dfefa15f238a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "ColorBar(colormap=LinearColorScale(domain=(0.0, 1.0), range=('red', 'blue')), length=500, orientation='horizon…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "visualize(\n",
+    "    LinearColorScale(range=('red', 'blue'))\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d763ac9fdfad4865acbb8b9000a8dbcf",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "ColorBar(colormap=LogColorScale(domain=(1.0, 10.0), range=('green', 'orange')), length=500, orientation='horiz…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "visualize(\n",
+    "    LogColorScale(range=('green', 'orange'), base=10)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5d354bffcb594efab5925f74ab9d9007",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "ColorBar(colormap=NamedSequentialColorMap(domain=(0.0, 1.0)), length=500, orientation='horizontal')"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "visualize(\n",
+    "    NamedSequentialColorMap('Viridis')\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a7a0b70e6ece4cc1a287ccb42b96e316",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "ColorBar(colormap=NamedDivergingColorMap(domain=(-1.0, 0.0, 1.0), name='RdBu'), length=500, orientation='horiz…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "visualize(\n",
+    "    NamedDivergingColorMap('RdBu', domain=(-1, 0, 1))\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "73a26fd966ea47d2a2539a6a7178b0e6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "ColorBar(colormap=NamedOrdinalColorMap(cardinality=8, domain=(0, 1, 2, 3, 4, 5, 6, 7, 8, 9), name='Accent'), l…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "visualize(\n",
+    "    NamedOrdinalColorMap('Accent', domain=tuple(range(10)))\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "035d8328a73e4ca78bce91c5ce29c5ba",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "ColorBar(colormap=NamedDivergingColorMap(clamp=True, domain=(0.0, 4.0, 8.0), name='PiYG'), length=500, orienta…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "visualize(\n",
+    "    NamedDivergingColorMap('PiYG', domain=(0, 4, 8), clamp=True)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {
+     "064c563dc7304e62bbdab5e63be9ab6c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.1.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "3306014434b94a6aa4d61edc2da5a685": {
+      "model_module": "jupyter-scales",
+      "model_module_version": "^2.0.0",
+      "model_name": "NamedSequentialColorMap",
+      "state": {
+       "_model_module_version": "^2.0.0",
+       "_view_module_version": ""
+      }
+     },
+     "342d34801ed548619d3c1c76bd7eced7": {
+      "model_module": "jupyter-scales",
+      "model_module_version": "^2.0.0",
+      "model_name": "LinearColorScaleModel",
+      "state": {
+       "_model_module_version": "^2.0.0",
+       "_view_module_version": "",
+       "range": [
+        "red",
+        "blue"
+       ]
+      }
+     },
+     "3ff1c4239ee44aa4837615f531ee717f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.1.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5d354bffcb594efab5925f74ab9d9007": {
+      "model_module": "jupyter-scales",
+      "model_module_version": "^2.0.0",
+      "model_name": "ColorBarModel",
+      "state": {
+       "_model_module_version": "^2.0.0",
+       "_view_module_version": "^2.0.0",
+       "colormap": "IPY_MODEL_3306014434b94a6aa4d61edc2da5a685",
+       "layout": "IPY_MODEL_bcff32ee587e4d5588751fa4bcc5ccb5",
+       "length": 500,
+       "orientation": "horizontal"
+      }
+     },
+     "5e80550ffe0a4623b69948d7082adf3f": {
+      "model_module": "jupyter-scales",
+      "model_module_version": "^2.0.0",
+      "model_name": "NamedDivergingColorMap",
+      "state": {
+       "_model_module_version": "^2.0.0",
+       "_view_module_version": "",
+       "domain": [
+        -1,
+        0,
+        1
+       ],
+       "name": "RdBu"
+      }
+     },
+     "692de2a0492c47ffb7b3942dd46db00a": {
+      "model_module": "jupyter-scales",
+      "model_module_version": "^2.0.0",
+      "model_name": "LogColorScaleModel",
+      "state": {
+       "_model_module_version": "^2.0.0",
+       "_view_module_version": "",
+       "range": [
+        "green",
+        "orange"
+       ]
+      }
+     },
+     "73a26fd966ea47d2a2539a6a7178b0e6": {
+      "model_module": "jupyter-scales",
+      "model_module_version": "^2.0.0",
+      "model_name": "ColorBarModel",
+      "state": {
+       "_model_module_version": "^2.0.0",
+       "_view_module_version": "^2.0.0",
+       "colormap": "IPY_MODEL_924690e7d12247dd931a7d6c08597057",
+       "layout": "IPY_MODEL_ba87f6e8632a462da8f80c59c7a1a173",
+       "length": 500,
+       "orientation": "horizontal"
+      }
+     },
+     "924690e7d12247dd931a7d6c08597057": {
+      "model_module": "jupyter-scales",
+      "model_module_version": "^2.0.0",
+      "model_name": "NamedOrdinalColorMap",
+      "state": {
+       "_model_module_version": "^2.0.0",
+       "_view_module_version": "",
+       "cardinality": 8,
+       "domain": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9
+       ],
+       "name": "Accent"
+      }
+     },
+     "a7a0b70e6ece4cc1a287ccb42b96e316": {
+      "model_module": "jupyter-scales",
+      "model_module_version": "^2.0.0",
+      "model_name": "ColorBarModel",
+      "state": {
+       "_model_module_version": "^2.0.0",
+       "_view_module_version": "^2.0.0",
+       "colormap": "IPY_MODEL_5e80550ffe0a4623b69948d7082adf3f",
+       "layout": "IPY_MODEL_064c563dc7304e62bbdab5e63be9ab6c",
+       "length": 500,
+       "orientation": "horizontal"
+      }
+     },
+     "ba87f6e8632a462da8f80c59c7a1a173": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.1.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "bcff32ee587e4d5588751fa4bcc5ccb5": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.1.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c9d89b646aef4a73aaf6dfefa15f238a": {
+      "model_module": "jupyter-scales",
+      "model_module_version": "^2.0.0",
+      "model_name": "ColorBarModel",
+      "state": {
+       "_model_module_version": "^2.0.0",
+       "_view_module_version": "^2.0.0",
+       "colormap": "IPY_MODEL_342d34801ed548619d3c1c76bd7eced7",
+       "layout": "IPY_MODEL_d553ab6d1f544390ab36e5ed6f2fcb07",
+       "length": 500,
+       "orientation": "horizontal"
+      }
+     },
+     "d553ab6d1f544390ab36e5ed6f2fcb07": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.1.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d763ac9fdfad4865acbb8b9000a8dbcf": {
+      "model_module": "jupyter-scales",
+      "model_module_version": "^2.0.0",
+      "model_name": "ColorBarModel",
+      "state": {
+       "_model_module_version": "^2.0.0",
+       "_view_module_version": "^2.0.0",
+       "colormap": "IPY_MODEL_692de2a0492c47ffb7b3942dd46db00a",
+       "layout": "IPY_MODEL_3ff1c4239ee44aa4837615f531ee717f",
+       "length": 500,
+       "orientation": "horizontal"
+      }
+     }
+    },
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/introduction.ipynb
+++ b/examples/introduction.ipynb
@@ -1,12 +1,12 @@
 {
  "cells": [
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "# Introduction"
-     ]
-    },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Introduction"
+   ]
+  },
   {
    "cell_type": "code",
    "execution_count": 1,

--- a/ipyscales/__init__.py
+++ b/ipyscales/__init__.py
@@ -17,6 +17,7 @@ from .continuous import (
 from .color import (
     ColorScale, LinearColorScale, LogColorScale,
     NamedSequentialColorMap, NamedDivergingColorMap,
+    NamedOrdinalColorMap
 )
 from .colorbar import ColorBar, ColorMapEditor
 

--- a/ipyscales/color.py
+++ b/ipyscales/color.py
@@ -8,7 +8,10 @@
 Defines color scale widget, and any supporting functions
 """
 
-from traitlets import Float, Unicode, Bool, CaselessStrEnum, Undefined
+from traitlets import (
+    Float, Unicode, Bool, CaselessStrEnum, Undefined, Int,
+    TraitError, observe, validate
+)
 from ipywidgets import register, jslink, VBox
 
 from .scale import Scale, SequentialScale, DivergingScale, OrdinalScale
@@ -102,6 +105,32 @@ div_colormap_names = (
     "Spectral",
 )
 
+scheme_only_colormaps = {
+    # Name: fixed cardinality
+    'Category10': 10,
+    'Accent': 8,
+    'Dark2': 8,
+    'Paired': 12,
+    'Pastel1': 9,
+    'Pastel2': 8,
+    'Set1': 9,
+    'Set2': 8,
+    'Set3': 12,
+}
+
+# These sequential scales do not have a discreet variant:
+non_scheme_sequential = (
+    'CubehelixDefault',
+    'Rainbow',
+    'Warm',
+    'Cool',
+    'Sinebow',
+    'Viridis',
+    'Magma',
+    'Inferno',
+    'Plasma',
+)
+
 
 @register
 class NamedSequentialColorMap(SequentialScale, ColorScale):
@@ -151,3 +180,39 @@ class NamedDivergingColorMap(DivergingScale, ColorScale):
         children.append(w)
 
         return VBox(children=children)
+
+
+@register
+class NamedOrdinalColorMap(OrdinalScale, ColorScale):
+    """An ordinal scale widget for colors, initialized from a named color map.
+    """
+
+    _model_name = Unicode('NamedOrdinalColorMap').tag(sync=True)
+
+    name = CaselessStrEnum(
+        set(scheme_only_colormaps.keys()) |
+        (set(seq_colormap_names) - set(non_scheme_sequential)) |
+        set(div_colormap_names),
+        "Category10"
+    ).tag(sync=True)
+
+    cardinality = Int(10, min=3, max=12).tag(sync=True)
+
+    def __init__(self, name="Category10", cardinality=Undefined, **kwargs):
+        # Ensure correct N if fixed length scheme is used:
+        try:
+            cardinality = scheme_only_colormaps[name]
+        except KeyError:
+            pass
+        super(NamedOrdinalColorMap, self).__init__(name=name, cardinality=cardinality, **kwargs)
+
+    @observe('name', type='change')
+    def _on_name_change(self, change):
+        # Ensure that N gets updated if fixed length scheme is used:
+        try:
+            self.cardinality = scheme_only_colormaps[change['new']]
+        except KeyError:
+            pass
+
+    # Range is fixed by colormap name:
+    range = None

--- a/ipyscales/continuous.py
+++ b/ipyscales/continuous.py
@@ -53,6 +53,12 @@ class LogScale(ContinuousScale):
     """
     _model_name = Unicode('LogScaleModel').tag(sync=True)
 
+    domain = VarlenTuple(
+        trait=CFloat(),
+        default_value=(1., 10.),
+        minlen=2,
+    ).tag(sync=True)
+
     base = Float(10).tag(sync=True)
 
 @register

--- a/ipyscales/tests/test_color.py
+++ b/ipyscales/tests/test_color.py
@@ -10,7 +10,7 @@ from traitlets import TraitError
 
 from ..color import (
     LinearColorScale, LogColorScale, NamedSequentialColorMap,
-    NamedDivergingColorMap
+    NamedDivergingColorMap, NamedOrdinalColorMap
 )
 from ..colorbar import ColorMapEditor
 
@@ -93,3 +93,48 @@ def test_named_diverging_colorscale_edit():
     w = NamedDivergingColorMap()
     editor = w.edit()
     # just check that no exceptions are raised
+
+
+def test_named_ordinal_colorscale_creation_blank():
+    w = NamedOrdinalColorMap()
+    assert w.name == 'Category10'
+    assert w.cardinality == 10
+
+def test_named_ordinal_colorscale_creation_valid_fixed():
+    w = NamedOrdinalColorMap('Accent')
+    assert w.name == 'Accent'
+    assert w.cardinality == 8
+
+def test_named_ordinal_colorscale_creation_valid_free():
+    for i in range(3, 12):
+        w = NamedOrdinalColorMap('RdBu', i)
+        assert w.name == 'RdBu'
+        assert w.cardinality == i
+
+def test_named_ordinal_colorscale_creation_invalid_free():
+    with pytest.raises(TraitError):
+        NamedOrdinalColorMap('RdBu', 2)
+    with pytest.raises(TraitError):
+        NamedOrdinalColorMap('RdBu', 20)
+
+def test_named_ordinal_colorscale_creation_fixed_ignores():
+    w = NamedOrdinalColorMap('Accent', 25)
+    assert w.cardinality == 8
+
+def test_named_ordinal_colorscale_cardinality_changes():
+    w = NamedOrdinalColorMap('Accent', 25)
+    assert w.cardinality == 8
+    w.name = 'Category10'
+    assert w.cardinality == 10
+
+def test_named_ordinal_colorscale_cardinality_untouched():
+    w = NamedOrdinalColorMap('Accent', 25)
+    assert w.cardinality == 8
+    w.name = 'RdBu'
+    assert w.cardinality == 8
+
+def test_named_ordinal_colorscale_creation_invalid_name():
+    with pytest.raises(TraitError):
+        NamedOrdinalColorMap('Foobar')
+    with pytest.raises(TraitError):
+        NamedOrdinalColorMap('Viridis')

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1164,9 +1164,9 @@
       "dev": true
     },
     "chromabar": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/chromabar/-/chromabar-0.2.2.tgz",
-      "integrity": "sha512-OzQUCjIGOYgyZwC+DwLZUBaMq5RwzhH6uZgcgR2mQDwsRtufG8Wm7RZjqAG22rsVsTI8w37QpGJEoxeJvNt+6A==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/chromabar/-/chromabar-0.2.3.tgz",
+      "integrity": "sha512-c04WSqbokUcMA9Hyc/HD1zyniPdEh9ajaQc+eCQ9n+pK7v+GIxVnG/rXiIveJ46QfBeO67wzAM7TwWEdOwncTg==",
       "requires": {
         "d3-array": "^1.2.4",
         "d3-axis": "^1.0.12",

--- a/js/package.json
+++ b/js/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@jupyter-widgets/base": "^1.1.10",
     "@phosphor/coreutils": "^1.3.0",
-    "chromabar": "^0.2.2",
+    "chromabar": "^0.2.3",
     "d3-interpolate": "^1.3.2",
     "d3-scale": "^2.1.2",
     "d3-scale-chromatic": "^1.3.3",

--- a/js/src/continuous.ts
+++ b/js/src/continuous.ts
@@ -108,6 +108,7 @@ class LogScaleModel extends ContinuousScaleModel {
   defaults() {
     return {...super.defaults(),
       base: 10,
+      domain: [1, 10],
     };
   }
 

--- a/js/src/scale.ts
+++ b/js/src/scale.ts
@@ -395,6 +395,14 @@ export class OrdinalScaleModel extends ScaleModel {
 
   static serializers = {
     ...ScaleModel.serializers,
+    unknown: {
+      deserialize: (value?: any, manager?: ManagerBase<any>) => {
+        return value === null ? undefined : value
+      },
+      serialize: (value?: any, widget?: WidgetModel) => {
+        return value === undefined ? null : value
+      },
+    }
   }
 
   static model_name = 'OrdinalScaleModel';

--- a/js/tests/src/colormap.spec.ts
+++ b/js/tests/src/colormap.spec.ts
@@ -15,6 +15,7 @@ import {
   LinearColorScaleModel, LogColorScaleModel,
   NamedDivergingColorMap, NamedSequentialColorMap,
   colormapAsRGBArray, colormapAsRGBAArray,
+  NamedOrdinalColorMap
 } from '../../src/'
 
 
@@ -225,6 +226,67 @@ describe('ColorScales', () => {
             128, 187, 71, 1,
             79, 145, 37, 1,
           ]);
+        });
+    });
+
+  });
+
+  describe('NamedOrdinalColorMap', () => {
+
+    it('should be createable', () => {
+        let model = createTestModel(NamedOrdinalColorMap);
+        expect(model).to.be.an(NamedOrdinalColorMap);
+        return model.initPromise.then(() => {
+          expect(typeof model.obj).to.be('function');
+        });
+    });
+
+    it('should have expected default values in model', () => {
+        let model = createTestModel(NamedOrdinalColorMap);
+        expect(model).to.be.an(NamedOrdinalColorMap);
+        return model.initPromise.then(() => {
+          expect(model.get('name')).to.be('Category10');
+          expect(model.get('cardinality')).to.be(10);
+          expect(model.get('domain')).to.eql([]);
+        });
+    });
+
+    it('should have expected default values in object', () => {
+        let model = createTestModel(NamedOrdinalColorMap);
+        expect(model).to.be.an(NamedOrdinalColorMap);
+        return model.initPromise.then(() => {
+          expect(model.obj.domain()).to.eql([]);
+          expect(model.obj.range().length).to.eql(10);
+        });
+    });
+
+    it('should be createable with non-default values', () => {
+        let state = {
+          name: 'PuBuGn',
+          domain: [-1e7, 1e5],
+          cardinality: 3,
+        };
+        let model = createTestModel(NamedOrdinalColorMap, state);
+        return model.initPromise.then(() => {
+          expect(model.obj.domain()).to.eql([-1e7, 1e5]);
+          expect(model.obj.range()).to.eql(['#ece2f0', '#a6bddb', '#1c9099']);
+        });
+    });
+
+    it('should throw an error for invalid name', () => {
+        let state = {
+          name: 'FooBar',
+        };
+        expect(createTestModel).withArgs(NamedOrdinalColorMap, state)
+          .to.throwError(/^Unknown scheme name: FooBar/);
+    });
+
+    it('should throw an error for unkown range', () => {
+        let model = createTestModel(NamedOrdinalColorMap);
+        return model.initPromise.then(() => {
+          model.obj.range(['#ffffff', '#000000']);
+          expect(model.syncToModel.bind(model)).withArgs({}).to.throwError(
+            /^Unknown color scheme name /);
         });
     });
 

--- a/js/tests/src/colormap.spec.ts
+++ b/js/tests/src/colormap.spec.ts
@@ -189,7 +189,7 @@ describe('ColorScales', () => {
         expect(model).to.be.an(NamedDivergingColorMap);
         return model.initPromise.then(() => {
           expect(model.get('name')).to.be('BrBG');
-          expect(model.get('domain')).to.eql([0, 1]);
+          expect(model.get('domain')).to.eql([0, 0.5, 1]);
           expect(model.get('clamp')).to.be(false);
         });
     });
@@ -198,7 +198,7 @@ describe('ColorScales', () => {
         let model = createTestModel(NamedDivergingColorMap);
         expect(model).to.be.an(NamedDivergingColorMap);
         return model.initPromise.then(() => {
-          expect(model.obj.domain()).to.eql([0, 1]);
+          expect(model.obj.domain()).to.eql([0, 0.5, 1]);
           expect(model.obj.clamp()).to.be(false);
         });
     });
@@ -206,12 +206,12 @@ describe('ColorScales', () => {
     it('should be createable with non-default values', () => {
         let state = {
           name: 'PiYG',
-          domain: [-1e7, 1e5],
+          domain: [-1e7, 0, 1e5],
           clamp: true,
         };
         let model = createTestModel(NamedDivergingColorMap, state);
         return model.initPromise.then(() => {
-          expect(model.obj.domain()).to.eql([-1e7, 1e5]);
+          expect(model.obj.domain()).to.eql([-1e7, 0,  1e5]);
           expect(model.obj.clamp()).to.be(true);
           expect(colormapAsRGBAArray(model as any, 10)).to.eql([
             142, 1, 82, 1,

--- a/js/tests/src/colormap.spec.ts
+++ b/js/tests/src/colormap.spec.ts
@@ -84,7 +84,7 @@ describe('ColorScales', () => {
         expect(model).to.be.an(LogColorScaleModel);
         return model.initPromise.then(() => {
           expect(model.get('range')).to.eql(['black', 'white']);
-          expect(model.get('domain')).to.eql([0, 1]);
+          expect(model.get('domain')).to.eql([1, 10]);
           expect(model.get('clamp')).to.be(false);
           expect(model.get('interpolator')).to.be('interpolate');
         });
@@ -95,7 +95,7 @@ describe('ColorScales', () => {
         expect(model).to.be.an(LogColorScaleModel);
         return model.initPromise.then(() => {
           expect(model.obj.range()).to.eql(['black', 'white']);
-          expect(model.obj.domain()).to.eql([0, 1]);
+          expect(model.get('domain')).to.eql([1, 10]);
           expect(model.obj.clamp()).to.be(false);
           expect(model.obj.interpolate()).to.be(interpolate);
         });

--- a/js/tests/src/continuous.spec.ts
+++ b/js/tests/src/continuous.spec.ts
@@ -117,7 +117,7 @@ describe('LogScaleModel', () => {
       expect(model).to.be.an(LogScaleModel);
       return model.initPromise.then(() => {
         expect(model.get('range')).to.eql([0, 1]);
-        expect(model.get('domain')).to.eql([0, 1]);
+        expect(model.get('domain')).to.eql([1, 10]);
         expect(model.get('clamp')).to.be(false);
         expect(model.get('interpolator')).to.be('interpolate');
         expect(model.get('base')).to.be(10);
@@ -129,7 +129,7 @@ describe('LogScaleModel', () => {
       expect(model).to.be.an(LogScaleModel);
       return model.initPromise.then(() => {
         expect(model.obj.range()).to.eql([0, 1]);
-        expect(model.obj.domain()).to.eql([0, 1]);
+        expect(model.get('domain')).to.eql([1, 10]);
         expect(model.obj.clamp()).to.be(false);
         expect(model.obj.interpolate()).to.be(interpolate);
         expect(model.obj.base()).to.be(10);


### PR DESCRIPTION
- Change default domain of log scales to be (1, 10), as 0 is invalid for log scales (now it is power 0 and 1 of base).
- Fix unknown value for ordinal scales.
- Fix diverging color map (have it actually use `scaleDiverging`).
- Add ordinal color maps.
- Add example notebooks showing off all the color map types.