### PR TITLE
Update the jupyter-widgets/base dependency to be more inclusive

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -57,7 +57,7 @@
     "watch:nbextension": "webpack --watch -d"
   },
   "dependencies": {
-    "@jupyter-widgets/base": "^2.0.1",
+    "@jupyter-widgets/base": "^1.1.10 || ^2.0.1",
     "@phosphor/coreutils": "^1.3.0",
     "chromabar": "^0.6.1",
     "d3-interpolate": "^1.3.2",


### PR DESCRIPTION
We can have either the old version *or* the new 2.0 version

Can we get an npm release with the ^2 version? The npm published package still requires base ^1.1.10.