### PR TITLE
Updates for lab 2 + various fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - 3.8
   - 3.7
   - 3.6
 sudo: false
@@ -22,7 +23,7 @@ matrix:
 cache:
   pip: true
   directories:
-    - node_modules # NPM packages
+    - js/node_modules # NPM packages
     - $HOME/.npm
 before_install:
   - pip install -U pip setuptools

--- a/examples/scaled-data.ipynb
+++ b/examples/scaled-data.ipynb
@@ -75,7 +75,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Set up our scaled data source. This will not synchronize the scaled data, but if passed to a data union trait, the scaled data will be used:"
+    "Set up our scaled data source. This will not transmit the scaled data back to the kernel, but if passed to a data union trait, the scaled data will be used:"
    ]
   },
   {

--- a/js/package.json
+++ b/js/package.json
@@ -8,6 +8,19 @@
     "jupyterlab-extension",
     "widgets"
   ],
+  "homepage": "https://github.com/vidartf/ipyscales",
+  "bugs": {
+    "url": "https://github.com/vidartf/ipyscales/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vidartf/ipyscales"
+  },
+  "license": "BSD-3-Clause",
+  "author": {
+    "name": "Jupyter Development Team",
+    "email": "jupyter@googlegroups.com"
+  },
   "files": [
     "lib/**/*.js",
     "lib/**/*.js.map",
@@ -18,55 +31,44 @@
     "src/**/*",
     "styles/**/*"
   ],
-  "homepage": "https://github.com/vidartf/ipyscales",
-  "bugs": {
-    "url": "https://github.com/vidartf/ipyscales/issues"
-  },
-  "license": "BSD-3-Clause",
-  "author": {
-    "name": "Jupyter Development Team",
-    "email": "jupyter@googlegroups.com"
-  },
   "main": "lib/index.js",
   "types": "./lib/index.d.ts",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/vidartf/ipyscales"
-  },
   "scripts": {
     "build": "npm run build:lib && npm run build:nbextension",
+    "build:all": "npm run build:labextension && npm run build:nbextension",
     "build:labextension": "npm run clean:labextension && mkdirp lab-dist && cd lab-dist && npm pack ..",
     "build:lib": "tsc",
     "build:nbextension": "webpack -p",
-    "build:all": "npm run build:labextension && npm run build:nbextension",
     "clean": "npm run clean:lib && npm run clean:nbextension",
-    "clean:lib": "rimraf lib",
     "clean:labextension": "rimraf lab-dist",
+    "clean:lib": "rimraf lib",
     "clean:nbextension": "rimraf ../ipyscales/nbextension/static/index.js",
     "prepack": "npm run build:lib",
     "prepublishOnly": "npm run clean && npm run build",
     "test": "npm run test:chrome",
-    "test:ci": "karma start --browsers=ChromeCI tests/karma.conf.js",
     "test:chrome": "karma start --browsers=Chrome tests/karma.conf.js",
-    "test:dev": "karma start --browsers=Chrome --singleRun=false tests/karma.conf.js",
+    "test:ci": "karma start --browsers=ChromeCI tests/karma.conf.js",
     "test:debug": "karma start --browsers=Chrome --debug=true tests/karma.conf.js",
+    "test:dev": "karma start --browsers=Chrome --singleRun=false tests/karma.conf.js",
     "test:firefox": "karma start --browsers=Firefox tests/karma.conf.js",
     "test:ie": "karma start --browsers=IE tests/karma.conf.js",
+    "update:all": "update-dependency --minimal --regex .*",
     "watch": "npm-run-all -p watch:*",
     "watch:lib": "tsc -w",
     "watch:nbextension": "webpack --watch -d"
   },
   "dependencies": {
-    "@jupyter-widgets/base": "^2.0.1",
+    "@jupyter-widgets/base": "^2.0.1 || ^3.0.0",
     "@phosphor/coreutils": "^1.3.0",
-    "chromabar": "^0.6.1",
+    "chromabar": "^0.6.2",
     "d3-interpolate": "^1.3.2",
     "d3-scale-chromatic": "^1.3.3",
-    "jupyter-dataserializers": "^2.0.2",
-    "jupyter-datawidgets": "^5.1.0",
+    "jupyter-dataserializers": "^2.2.0",
+    "jupyter-datawidgets": "^5.3.0",
     "ndarray": "^1.0.18"
   },
   "devDependencies": {
+    "@jupyterlab/buildutils": "^2.1.0",
     "@phosphor/application": "^1.6.0",
     "@phosphor/widgets": "^1.6.0",
     "@types/d3-interpolate": "^1.3.1",
@@ -74,27 +76,27 @@
     "@types/d3-scale-chromatic": "^1.3.1",
     "@types/d3-selection": "^1.4.1",
     "@types/expect.js": "^0.3.29",
-    "@types/mocha": "^5.2.5",
+    "@types/mocha": "^7.0.2",
     "@types/ndarray": "^1.0.6",
-    "@types/node": "^12.6.9",
+    "@types/node": "^14.0.13",
     "@types/webpack-env": "^1.13.6",
     "expect.js": "^0.3.1",
     "json-loader": "^0.5.7",
-    "karma": "^4.2.0",
+    "karma": "^5.1.0",
     "karma-chrome-launcher": "^3.0.0",
     "karma-firefox-launcher": "^1.1.0",
     "karma-ie-launcher": "^1.0.0",
-    "karma-mocha": "^1.3.0",
+    "karma-mocha": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
     "karma-typescript": "^4.1.1",
     "karma-typescript-es6-transform": "^4.1.1",
-    "mkdirp": "^0.5.1",
-    "mocha": "^6.2.0",
+    "mkdirp": "^1.0.4",
+    "mocha": "^8.0.1",
     "npm-run-all": "^4.1.3",
-    "rimraf": "^2.6.2",
-    "source-map-loader": "^0.2.4",
-    "ts-loader": "^6.0.4",
-    "typescript": "~3.6.3",
+    "rimraf": "^3.0.2",
+    "source-map-loader": "^1.0.0",
+    "ts-loader": "^7.0.5",
+    "typescript": "^3.9.5",
     "webpack": "^4.39.1",
     "webpack-cli": "^3.3.6"
   },

--- a/js/src/plugin.ts
+++ b/js/src/plugin.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  Application, IPlugin
+  Application, /*IPlugin*/
 } from '@phosphor/application';
 
 import {
@@ -26,7 +26,7 @@ const EXTENSION_ID = 'jupyter-scales:plugin';
 /**
  * The example plugin.
  */
-const plugin: IPlugin<Application<Widget>, void> = {
+const plugin: any /* IPlugin<Application<any >, void>  Only until phosphor -> lumino rename is completed */ = {
   id: EXTENSION_ID,
   requires: [IJupyterWidgetRegistry],
   activate: activateWidgetExtension,

--- a/js/src/widgets.ts
+++ b/js/src/widgets.ts
@@ -23,6 +23,13 @@ export {
 export { ScaledArrayModel } from './datawidgets';
 
 export {
+  QuantizeScaleModel,
+  QuantileScaleModel,
+  TresholdScaleModel,
+  OrdinalScaleModel,
+} from './scale';
+
+export {
   DropdownView,
   StringDropdownModel,
   WidgetDropdownModel

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup_args = dict(
             "ipydatawidgets>=4.0",
             "ipywidgets>=7.5",
             "nbval",
-            "pytest>=3.6",
+            "pytest>=4.6",
             "pytest-cov",
             "pytest_check_links",
         ],


### PR DESCRIPTION
- Updates to support lab 2:
  - Add support for `@jupyter-widgets/base` ver 3.
  - Update JS deps to ensure versions that support lab 2.
- Update some dev deps
- Add some missing JS exports that mean 4 widget types could not be used!
- Various cleanup.